### PR TITLE
新規会員登録画面への遷移

### DIFF
--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -59,4 +59,4 @@
 <%= render "public/shared/links" %>
 
 <p>すでに登録済みの方</p>
-<p><%= link_to 'こちら', new_user_session_path %>からログインしてください</p>
+<p><%= link_to 'こちら', new_customer_session_path %>からログインしてください</p>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -26,4 +26,4 @@
 <%= render "public/shared/links" %>
 
 <p>会員登録がお済みでない方</p>
-<p><%= link_to 'こちら', new_user_registration_path %>から新規登録を行ってください</p>
+<p><%= link_to 'こちら', new_customer_registration_path %>から新規登録を行ってください</p>


### PR DESCRIPTION
topページから新規会員登録ページへ遷移できなかったため、修正しました。